### PR TITLE
Remove Noisy Log

### DIFF
--- a/server/internal/genreengine/onnx.go
+++ b/server/internal/genreengine/onnx.go
@@ -204,10 +204,6 @@ func (e *ONNXEngine) Classify(ctx context.Context, filePath string, topN int) (R
 			}
 			topTagsWithProbs[i] = fmt.Sprintf("%s(%.3f)", tag, prob)
 		}
-		logger.InfoC(ctx, "onnx model classification result",
-			slog.String("model", name),
-			slog.String("predictions", strings.Join(topTagsWithProbs, ", ")))
-
 		lists = append(lists, topTags)
 	}
 


### PR DESCRIPTION
Remove a noisy log for the genre engine. 
This pull request makes a small change to the logging behavior in the ONNX genre engine. The log statement that previously reported model classification results has been removed from the `Classify` method in `onnx.go`.

- Removed the `logger.InfoC` statement that logged ONNX model classification results, reducing log verbosity in the `Classify` method (`server/internal/genreengine/onnx.go`).